### PR TITLE
EFA-7664: [PrintNow] Sometimes the PaperSize is missing in PrintNow

### DIFF
--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -455,6 +455,9 @@ export class EzpPrinterSelection {
       this.selectedProperties.paperid = this.selectedPrinterConfig.PaperFormats.find((el) =>
         el.Name.includes(format)
       ).Id
+    } else {
+      this.selectedProperties.paper = this.selectedPrinterConfig.PaperFormats[0].Name
+      this.selectedProperties.paperid = this.selectedPrinterConfig.PaperFormats[0].Id
     }
   }
 


### PR DESCRIPTION
If the printer does not support the defaults (A$/Letter), then the first one from formats array is shown.