### PR TITLE
Integrate the updated sfAPI in to ezeep.js.

### DIFF
--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -92,8 +92,16 @@ export interface Trays {
 }
 
 export interface PrinterConfig {
+  Preset?: {
+    Duplex?: string
+    Color?: string
+    Resolution?: string
+    Paper?: string
+    Tray?: string
+  },
   Collate?: boolean
   Color?: boolean
+  ColorSupported?: boolean
   Driver?: string
   DuplexMode?: number
   DuplexSupported?: boolean
@@ -106,6 +114,7 @@ export interface PrinterConfig {
   OrientationsSupportedId?: Array<number>
   PaperFormats?: Array<PaperFormat>
   Resolutions?: Array<string>
+  DefaultResolution?: string
   TPUID?: number
   Trays?: Array<Trays>
 }


### PR DESCRIPTION
- Modified the response type for sfapi/GetPrinterProperties/{printerId} according to the specification in RFC https://www.notion.so/cortado/RFC-Setting-printer-default-properties-in-print-jobs-optionally-affected-by-printer-profile-392c18c8e2fe4cb8b51df68dccbffefc?pvs=4