### PR TITLE
Display printer preset values by default for color, duplex, paper format, resolution, tray fields

### DIFF
--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -27,7 +27,7 @@ export class EzpPrinterSelection {
   private sasUri = ''
   private fileExtension = ''
   private printService: EzpPrintService
-  private duplexOptions = [
+  public duplexOptions = [
     {
       id: 1,
       title: i18next.t('printer_selection.duplex_none'),
@@ -311,9 +311,6 @@ export class EzpPrinterSelection {
     localStorage.setItem('properties', JSON.stringify(this.selectedProperties))
     localStorage.setItem('printer', JSON.stringify(this.selectedPrinter))
 
-    // localStorage.removeItem('printer')
-    // localStorage.removeItem('properties')  
-
     this.printStopped = false
   }
 
@@ -369,9 +366,9 @@ export class EzpPrinterSelection {
         await this.printService
           .getPrinterProperties(authStore.state.accessToken, this.selectedPrinter.id)
           .then((data) => {
-            this.selectedPrinterConfig = data[0]
+            this.selectedPrinterConfig =  {...this.selectedPrinterConfig, ...data[0]}
           })
-        this.setDefaultPaperFormat()
+        // this.setDefaultPaperFormat()
         console.log(this.selectedPrinterConfig)
         break
       case 'color':
@@ -743,23 +740,21 @@ export class EzpPrinterSelection {
                 icon="duplex"
                 placeholder={i18next.t('printer_selection.select_duplex')}
                 toggleFlow="horizontal"
-                options={this.duplexOptions.map((option) => ({
+                options={this.duplexOptions?.map((option) => ({
                   id: option.id,
                   title: option.title,
                   meta: '',
                   type: 'duplex',
                 }))}
                 preSelected={
-                  this.selectedPrinter.id 
-                  && this.selectedPrinterConfig.Profile?.Duplex == "duplex_simplex" 
+                  this.selectedPrinter.id && this.selectedPrinterConfig.Profile?.Duplex == "duplex_simplex" 
                   ? i18next.t('printer_selection.duplex_none') 
                   : this.selectedPrinterConfig.Profile?.Duplex == "duplex_vertical" 
                   ? i18next.t('printer_selection.duplex_long') 
                   : this.selectedPrinterConfig.Profile?.Duplex == "duplex_horizontal"
                   ? i18next.t('printer_selection.duplex_short')
-                  : null
-                }
-                disabled={!this.selectedPrinterConfig.DuplexSupported || this.selectedPrinterConfig.Profile.Duplex == "simplex" }
+                  : null}
+                disabled={!this.selectedPrinterConfig.DuplexSupported}
               />
               <ezp-select
                 label={i18next.t('printer_selection.size')}
@@ -774,10 +769,8 @@ export class EzpPrinterSelection {
                   type: 'format',
                 }))}
                 preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.PaperFormats?.find((el) =>
-                  el.Name.includes(this.selectedPrinterConfig.Profile.Paper)) 
-                  ? this.selectedPrinterConfig.Profile.Paper 
-                  : this.selectedPrinterConfig.Profile.Paper == null 
-                  ? this.selectedPrinterConfig.PaperFormats[0]?.Name 
+                  el.Name.includes(this.selectedPrinterConfig.Profile?.Paper)) 
+                  ? this.selectedPrinterConfig.Profile?.Paper 
                   : null}
                 disabled={!(this.selectedPrinterConfig.PaperFormats?.length > 0)}
               />
@@ -822,7 +815,7 @@ export class EzpPrinterSelection {
                 icon="quality"
                 placeholder={i18next.t('printer_selection.select_quality')}
                 toggleFlow="horizontal"
-                options={this.selectedPrinterConfig.Resolutions && this.selectedPrinterConfig.Resolutions.map((option, index) => ({
+                options={this.selectedPrinterConfig.Resolutions?.map((option, index) => ({
                   id: index,
                   title: option,
                   meta: '',
@@ -830,8 +823,6 @@ export class EzpPrinterSelection {
                 }))}
                 preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Resolutions?.includes(this.selectedPrinterConfig.Profile.Resolution) 
                   ? this.selectedPrinterConfig.Profile.Resolution 
-                  : this.selectedPrinterConfig.Profile.Resolution == null 
-                  ? this.selectedPrinterConfig.Resolutions[0]
                   : null}
                 disabled={!(this.selectedPrinterConfig.Resolutions?.length > 0)}
               />
@@ -852,8 +843,6 @@ export class EzpPrinterSelection {
                 preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Trays?.find((el) =>
                  el.Name.includes(this.selectedPrinterConfig.Profile.Tray)) 
                  ? this.selectedPrinterConfig.Profile.Tray 
-                 : this.selectedPrinterConfig.Profile.Tray == null 
-                 ? this.selectedPrinterConfig.Trays[0]?.Name
                  : null}
               /> ) : null}
               <ezp-input

--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -80,6 +80,13 @@ export class EzpPrinterSelection {
   @State() selectedPrinter: Printer
   @State() printerConfig: PrinterConfig[]
   @State() selectedPrinterConfig: PrinterConfig = {
+    Preset: {
+      Color: '',
+      Duplex: '',
+      Paper: '',
+      Resolution: '',
+      Tray: ''
+    },
     OrientationsSupported: [],
     PaperFormats: [],
     Resolutions: [],
@@ -358,7 +365,7 @@ export class EzpPrinterSelection {
         await this.printService
           .getPrinterProperties(authStore.state.accessToken, this.selectedPrinter.id)
           .then((data) => (this.selectedPrinterConfig = data[0]))
-        this.setDefaultPaperFormat()
+        // this.setDefaultPaperFormat()
         break
       case 'color':
         this.selectedProperties.color = !!eventDetails.id
@@ -717,12 +724,12 @@ export class EzpPrinterSelection {
                 }
                 preSelected={
                   this.selectedPrinter.id
-                    ? this.selectedProperties.color
+                    ? this.selectedPrinterConfig.Preset.Color == "color"
                       ? i18next.t('printer_selection.color_color')
                       : i18next.t('printer_selection.color_grayscale')
                     : null
                 }
-                disabled={!this.selectedPrinterConfig.Color}
+                disabled={!this.selectedPrinterConfig.ColorSupported}
               />
               <ezp-select
                 label={i18next.t('printer_selection.duplex')}
@@ -736,12 +743,15 @@ export class EzpPrinterSelection {
                   type: 'duplex',
                 }))}
                 preSelected={
-                  this.selectedPrinter.id && this.selectedProperties.duplex
-                    ? this.duplexOptions.find(
-                      (option) => option.id === this.selectedProperties.duplexmode
-                    ).id
-                    : null
-                }
+                  this.selectedPrinter.id 
+                  && this.selectedPrinterConfig.Preset.Duplex == "duplex_simplex" 
+                  ? i18next.t('printer_selection.duplex_none') 
+                  : this.selectedPrinterConfig.Preset.Duplex == "duplex_vertical" 
+                  ? i18next.t('printer_selection.duplex_long') 
+                  : this.selectedPrinterConfig.Preset.Duplex == "duplex_horizontal"
+                  ? i18next.t('printer_selection.duplex_short')
+                  : null
+                 }
                 disabled={!this.selectedPrinterConfig.DuplexSupported}
               />
               <ezp-select
@@ -756,7 +766,8 @@ export class EzpPrinterSelection {
                   meta: `${format.XRes} x ${format.YRes}`,
                   type: 'format',
                 }))}
-                preSelected={this.selectedPrinter.id ? this.selectedProperties.paper : null}
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.PaperFormats.find((el) =>
+                  el.Name.includes(this.selectedPrinterConfig.Preset.Paper)) ? this.selectedPrinterConfig.Preset.Paper : null}
                 disabled={!(this.selectedPrinterConfig.PaperFormats.length > 0)}
               />
               {this.paperid == PAPER_ID ? (
@@ -806,7 +817,7 @@ export class EzpPrinterSelection {
                   meta: '',
                   type: 'quality',
                 }))}
-                preSelected={this.selectedPrinter.id ? this.selectedProperties.resolution : null}
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Resolutions.includes(this.selectedPrinterConfig.Preset.Resolution) ? this.selectedPrinterConfig.Preset.Resolution : null}
                 disabled={!(this.selectedPrinterConfig.Resolutions.length > 0)}
               />
              {this.selectedPrinterConfig.Trays.length >= 1 && this.selectedPrinterConfig.Trays[0] != null ? (
@@ -821,7 +832,10 @@ export class EzpPrinterSelection {
                   id: trays.Index,
                   meta: '',
                   type: 'tray',
-                }))}
+                })
+                )}
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Trays.find((el) =>
+                 el.Name.includes(this.selectedPrinterConfig.Preset.Tray)) ? this.selectedPrinterConfig.Preset.Tray : null}
               /> ) : null}
               <ezp-input
                   icon="paper_range"

--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -369,7 +369,6 @@ export class EzpPrinterSelection {
             this.selectedPrinterConfig =  {...this.selectedPrinterConfig, ...data[0]}
           })
         // this.setDefaultPaperFormat()
-        console.log(this.selectedPrinterConfig)
         break
       case 'color':
         this.selectedProperties.color = !!eventDetails.id

--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -724,7 +724,7 @@ export class EzpPrinterSelection {
                 }
                 preSelected={
                   this.selectedPrinter.id
-                    ? this.selectedPrinterConfig.Preset.Color == "color"
+                    ? this.selectedPrinterConfig.Preset && this.selectedPrinterConfig.Preset.Color == "color"
                       ? i18next.t('printer_selection.color_color')
                       : i18next.t('printer_selection.color_grayscale')
                     : null
@@ -744,11 +744,11 @@ export class EzpPrinterSelection {
                 }))}
                 preSelected={
                   this.selectedPrinter.id 
-                  && this.selectedPrinterConfig.Preset.Duplex == "duplex_simplex" 
+                  && this.selectedPrinterConfig.Preset && this.selectedPrinterConfig.Preset.Duplex == "duplex_simplex" 
                   ? i18next.t('printer_selection.duplex_none') 
-                  : this.selectedPrinterConfig.Preset.Duplex == "duplex_vertical" 
+                  : this.selectedPrinterConfig.Preset && this.selectedPrinterConfig.Preset.Duplex == "duplex_vertical" 
                   ? i18next.t('printer_selection.duplex_long') 
-                  : this.selectedPrinterConfig.Preset.Duplex == "duplex_horizontal"
+                  : this.selectedPrinterConfig.Preset && this.selectedPrinterConfig.Preset.Duplex == "duplex_horizontal"
                   ? i18next.t('printer_selection.duplex_short')
                   : null
                  }
@@ -760,15 +760,15 @@ export class EzpPrinterSelection {
                 placeholder={i18next.t('printer_selection.select_size')}
                 toggleFlow="horizontal"
                 optionFlow="horizontal"
-                options={this.selectedPrinterConfig.PaperFormats.map((format) => ({
+                options={this.selectedPrinterConfig.PaperFormats && this.selectedPrinterConfig.PaperFormats.map((format) => ({
                   id: format.Id,
                   title: format.Name,
                   meta: `${format.XRes} x ${format.YRes}`,
                   type: 'format',
                 }))}
-                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.PaperFormats.find((el) =>
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.PaperFormats && this.selectedPrinterConfig.PaperFormats.find((el) =>
                   el.Name.includes(this.selectedPrinterConfig.Preset.Paper)) ? this.selectedPrinterConfig.Preset.Paper : null}
-                disabled={!(this.selectedPrinterConfig.PaperFormats.length > 0)}
+                disabled={!(this.selectedPrinterConfig.PaperFormats && this.selectedPrinterConfig.PaperFormats.length > 0)}
               />
               {this.paperid == PAPER_ID ? (
                 <>
@@ -811,30 +811,30 @@ export class EzpPrinterSelection {
                 icon="quality"
                 placeholder={i18next.t('printer_selection.select_quality')}
                 toggleFlow="horizontal"
-                options={this.selectedPrinterConfig.Resolutions.map((option, index) => ({
+                options={this.selectedPrinterConfig.Resolutions && this.selectedPrinterConfig.Resolutions.map((option, index) => ({
                   id: index,
                   title: option,
                   meta: '',
                   type: 'quality',
                 }))}
-                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Resolutions.includes(this.selectedPrinterConfig.Preset.Resolution) ? this.selectedPrinterConfig.Preset.Resolution : null}
-                disabled={!(this.selectedPrinterConfig.Resolutions.length > 0)}
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Resolutions && this.selectedPrinterConfig.Resolutions.includes(this.selectedPrinterConfig.Preset.Resolution) ? this.selectedPrinterConfig.Preset.Resolution : null}
+                disabled={!(this.selectedPrinterConfig.Resolutions && this.selectedPrinterConfig.Resolutions.length > 0)}
               />
-             {this.selectedPrinterConfig.Trays.length >= 1 && this.selectedPrinterConfig.Trays[0] != null ? (
+             {this.selectedPrinterConfig.Trays && this.selectedPrinterConfig.Trays.length >= 1 && this.selectedPrinterConfig.Trays[0] != null ? (
               <ezp-select
                 label={i18next.t('printer_selection.trays')}
                 icon="trays"
                 placeholder={i18next.t('printer_selection.select_trays')}
                 toggleFlow="horizontal"
                 optionFlow="horizontal"
-                options={this.selectedPrinterConfig.Trays.length >= 1 && this.selectedPrinterConfig.Trays.map((trays) => ({
+                options={this.selectedPrinterConfig.Trays && this.selectedPrinterConfig.Trays.length >= 1 && this.selectedPrinterConfig.Trays.map((trays) => ({
                   title: trays.Name,
                   id: trays.Index,
                   meta: '',
                   type: 'tray',
                 })
                 )}
-                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Trays.find((el) =>
+                preSelected={this.selectedPrinter.id && this.selectedPrinterConfig.Trays && this.selectedPrinterConfig.Trays.find((el) =>
                  el.Name.includes(this.selectedPrinterConfig.Preset.Tray)) ? this.selectedPrinterConfig.Preset.Tray : null}
               /> ) : null}
               <ezp-input

--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -411,7 +411,7 @@ export class EzpPrinterSelection {
       case 'paper_ranges':
           this.selectedProperties.PageRanges = eventDetails.value;
           this.pageRangeInvalid = !validatePageRange(this.selectedProperties.PageRanges);
-          
+          localStorage.setItem('pageRanges', JSON.stringify(this.selectedProperties.PageRanges));
           // console.log(this.selectedProperties.PageRanges)
           break  
       case 'duplex':
@@ -848,7 +848,7 @@ export class EzpPrinterSelection {
                   icon="paper_range"
                   suffix=""
                   placeholder="1-2,4-5,8"
-                  value={this.selectedProperties.PageRanges}
+                  value={localStorage.getItem('pageRanges') ? this.selectedProperties.PageRanges : ''}
                   eventType="paper_ranges"
                   type="text"
                   label={i18next.t('printer_selection.page_ranges')}

--- a/src/components/ezp-select/ezp-select.tsx
+++ b/src/components/ezp-select/ezp-select.tsx
@@ -115,6 +115,11 @@ export class EzpSelect {
     }
   }
 
+  @Watch('preSelected')
+  preSelectedChanged() {
+    this.preSelect();
+  }
+
   /**
    *
    * Private methods

--- a/src/components/ezp-select/ezp-select.tsx
+++ b/src/components/ezp-select/ezp-select.tsx
@@ -139,7 +139,7 @@ export class EzpSelect {
   }
 
   private select = (id: number | string | boolean) => {
-    const delay = this.selected.id === id ? 0 : this.duration * 1000
+    const delay = this.selected?.id === id ? 0 : this.duration * 1000
 
     this.selected = this.options.find((option) => option.id === id)
     this.selectSelection.emit(this.selected)
@@ -224,7 +224,7 @@ export class EzpSelect {
             <ezp-label
               id="value"
               ellipsis
-              text={this.selected.title !== '' ? this.selected.title : this.placeholder}
+              text={this.selected?.title !== '' ? this.selected?.title : this.placeholder}
             />
             <ezp-icon id="accessory" name="expand" />
           </div>
@@ -233,7 +233,7 @@ export class EzpSelect {
               if (option.title !== '') {
                 return (
                   <div
-                    class={`option ${option.id === this.selected.id ? 'is-selected' : ''} ${
+                    class={`option ${option.id === this.selected?.id ? 'is-selected' : ''} ${
                       option.meta !== '' ? 'has-meta' : ''
                     } `}
                     onClick={() => this.select(option.id)}

--- a/src/components/ezp-select/ezp-select.tsx
+++ b/src/components/ezp-select/ezp-select.tsx
@@ -150,7 +150,7 @@ export class EzpSelect {
   }
 
   private preSelect = () => {
-    this.selected = this.options.find((option) =>
+    this.selected = this.options?.find((option) =>
       typeof this.preSelected === 'number'
         ? option.id === this.preSelected
         : typeof this.preSelected === 'string'
@@ -190,7 +190,7 @@ export class EzpSelect {
 
   componentWillUpdate() {
     if (
-      this.selected.id === false &&
+      this.selected?.id === false &&
       this.preSelected !== undefined &&
       this.preSelected !== '' &&
       this.preSelected !== null
@@ -229,7 +229,7 @@ export class EzpSelect {
             <ezp-icon id="accessory" name="expand" />
           </div>
           <div id="list" ref={(element) => (this.list = element)}>
-            {this.options.map((option) => {
+            {this.options?.map((option) => {
               if (option.title !== '') {
                 return (
                   <div

--- a/src/components/ezp-upload/ezp-upload.tsx
+++ b/src/components/ezp-upload/ezp-upload.tsx
@@ -74,6 +74,7 @@ export class EzpUpload {
   private handleInput = () => {
     this.filename = this.input.files[0].name
     this.uploadFile.emit(this.input.files)
+    localStorage.removeItem('pageRanges');
   }
 
   /**

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -83,6 +83,7 @@ export interface PaperFormat {
   Name: string
   XRes: number
   YRes: number
+  Default: boolean
 }
 
 export interface Trays {

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -93,9 +93,10 @@ export interface Trays {
 }
 
 export interface PrinterConfig {
-  Preset?: {
+  Profile?: {
     Duplex?: string
     Color?: string
+    Orientation?: string
     Resolution?: string
     Paper?: string
     Tray?: string


### PR DESCRIPTION
- the pull request contains changes for displaying the printer preset defaults in the respective fields for color, duplex, paper format, resolution, tray fields.
- API endpoint sfapi/GetPrinterProperties/{printer_id} has a new property called Preset that has preset values for the aforementioned properties.
- when **ColorSupported** returns false, the Color field should be disabled.

Challenge:
- When selecting another printer, the printer properties object is not rendered as expected in the UI. Printer properties should be displayed appropriately when switching between printers. 