### PR TITLE
Fix ezp-stepper max prop and user input for copies

### DIFF
--- a/src/components/ezp-printer-selection/ezp-printer-selection.tsx
+++ b/src/components/ezp-printer-selection/ezp-printer-selection.tsx
@@ -1229,7 +1229,7 @@ export class EzpPrinterSelection {
                 label={i18next.t('printer_selection.page_ranges')}
               />
             </div>
-            <ezp-stepper label={i18next.t('printer_selection.copies')} max={10} icon="copies" />
+            <ezp-stepper label={i18next.t('printer_selection.copies')} icon="copies" />
           </div>
           <div id="footer">
             <ezp-text-button

--- a/src/components/ezp-stepper/ezp-stepper.tsx
+++ b/src/components/ezp-stepper/ezp-stepper.tsx
@@ -9,6 +9,20 @@ import { IconNameTypes } from '../../shared/types'
 export class EzpStepper {
   private input?: HTMLInputElement
 
+  private static readonly ALLOWED_KEYS = [
+    'Backspace',
+    'Delete',
+    'Tab',
+    'Escape',
+    'Enter',
+    'ArrowLeft',
+    'ArrowUp',
+    'ArrowRight',
+    'ArrowDown',
+  ]
+
+  private static readonly CTRL_CMD_KEYS = ['a', 'c', 'v', 'x']
+
   /**
    *
    * Properties
@@ -61,7 +75,8 @@ export class EzpStepper {
 
   @Watch('value')
   watchValue() {
-    this.canIncrease = this.max !== undefined ? this.value < this.max : true
+    const effectiveMax = this.max !== undefined ? Math.min(this.max, Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER
+    this.canIncrease = this.value < effectiveMax
     this.canDecrease = this.min !== undefined ? this.value > this.min : true
     this.stepperChanged.emit(this.value)
   }
@@ -73,15 +88,62 @@ export class EzpStepper {
    */
 
   private handleDecrease = () => {
-    this.value--
+    const newValue = this.value - 1
+    // Only decrease if within safe range and above minimum
+    if (newValue >= Number.MIN_SAFE_INTEGER && (this.min === undefined || newValue >= this.min)) {
+      this.value = newValue
+    }
   }
 
   private handleIncrease = () => {
-    this.value++
+    const newValue = this.value + 1
+    const effectiveMax = this.max !== undefined ? Math.min(this.max, Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER
+    // Only increase if within safe range and below maximum
+    if (newValue <= Number.MAX_SAFE_INTEGER && newValue <= effectiveMax) {
+      this.value = newValue
+    }
   }
 
   private handleInput = () => {
-    this.value = this.input.value !== '' ? parseInt(this.input.value) : this.min
+    if (!this.input) return
+
+    let inputString = this.input.value.trim()
+
+    // If the input is empty, set the value to the minimum
+    if (inputString === '') {
+      this.value = this.min
+      this.input.value = this.value.toString()
+      return
+    }
+
+    // Remove all non-digit characters, keep only numbers
+    const cleanedInput = inputString.replace(/\D/g, '')
+
+    // If nothing remains after cleaning, revert to the last valid value
+    if (cleanedInput === '') {
+      this.input.value = this.value.toString()
+      return
+    }
+
+    // Limit input length to prevent precision loss (MAX_SAFE_INTEGER has 16 digits)
+    const maxDigits = Number.MAX_SAFE_INTEGER.toString().length
+    const truncatedInput = cleanedInput.slice(0, maxDigits)
+
+    let inputValue = Number(truncatedInput)
+
+    // Safety check: ensure the number is within safe integer range
+    if (inputValue > Number.MAX_SAFE_INTEGER) {
+      inputValue = Number.MAX_SAFE_INTEGER
+    }
+
+    // Ensure the value is between min and max
+    if (this.min !== undefined && inputValue < this.min) inputValue = this.min
+    const effectiveMax = this.max !== undefined ? Math.min(this.max, Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER
+    if (inputValue > effectiveMax) inputValue = effectiveMax
+
+    // Update component state and input field
+    this.value = inputValue
+    this.input.value = inputValue.toString()
   }
 
   private setFocus = () => {
@@ -94,6 +156,21 @@ export class EzpStepper {
 
   private handleFocus = () => {
     this.focused = true
+  }
+  private handleKeyDown = (event: KeyboardEvent) => {
+    // If key is allowed or a Ctrl/Cmd combination, do nothing
+    if (
+      EzpStepper.ALLOWED_KEYS.includes(event.key) ||
+      ((event.ctrlKey || event.metaKey) && EzpStepper.CTRL_CMD_KEYS.includes(event.key.toLowerCase()))
+    ) {
+      return
+    }
+
+    // If the key is not a digit, prevent default behavior (block input)
+    const isDigit = /^\d$/.test(event.key)
+    if (!isDigit) {
+      event.preventDefault()
+    }
   }
 
   /**
@@ -123,9 +200,10 @@ export class EzpStepper {
           type="number"
           ref={(input) => (this.input = input)}
           min={this.min.toString()}
-          max={this.max.toString()}
+          max={this.max !== undefined ? this.max.toString() : undefined}
           value={this.value.toString()}
           onInput={this.handleInput}
+          onKeyDown={this.handleKeyDown}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
         />


### PR DESCRIPTION
* Fix rendering bug when max prop is removed
* Remove hardcoded max={10}
* Prevent invalid user input ("0", "1.5", "-1")
* Set a limit for manual input (currently Number.MAX_SAFE_INTEGER)