### PR TITLE
fix(ezp-printing): keep action buttons visible inside constrained par…

### DIFF
--- a/src/components/ezp-printing/ezp-printing.scss
+++ b/src/components/ezp-printing/ezp-printing.scss
@@ -29,6 +29,15 @@
   text-rendering: optimizeLegibility;
   -webkit-text-size-adjust: none;
 
+  /* Layout: stack ezp-upload and ezp-auth vertically inside parent's bounds.
+     ezp-upload takes available space (and scrolls internally if needed),
+     ezp-auth stays pinned at the bottom and is always visible. */
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  min-height: 0;
+  box-sizing: border-box;
+
   @include global.duration-declaration;
   @include global.spacing-declaration;
   @include global.easing-declaration;
@@ -80,4 +89,13 @@
       }
     }
   }
+}
+
+ezp-upload {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+ezp-auth {
+  flex-shrink: 0;
 }

--- a/src/components/ezp-upload/ezp-upload.scss
+++ b/src/components/ezp-upload/ezp-upload.scss
@@ -12,8 +12,12 @@
   box-sizing: border-box;
   color: var(--ezp-core-foreground-primary);
   display: grid;
-  grid-template: auto / minmax(auto, 280px);
+  grid-template-columns: minmax(auto, 480px);
+  grid-template-rows: minmax(0, 1fr);
   height: var(--ezp-upload-height, auto);
+  /* Allow shrinking when constrained by a flex parent (e.g. inside ezp-printing in a small modal). */
+  max-height: 100%;
+  min-height: 0;
   justify-content: center;
   padding: var(--ezp-spacing-3);
   position: relative;
@@ -31,18 +35,47 @@
   }
 }
 
+#form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
 #header {
   --ezp-icon-fill: var(--ezp-theme-solid);
 
   align-items: center;
   display: flex;
   filter: blur(var(--ezp-upload-header-blur, 0));
+  flex: 1 1 auto;
   flex-direction: column;
   gap: var(--ezp-spacing-5);
+  /* Center the content vertically when the host is taller than content
+     (e.g. standalone with --ezp-upload-height: 80vh). When the host is
+     constrained smaller than content (e.g. inside a modal), file-list's
+     overflow-y handles overflow gracefully. */
+  justify-content: center;
+  min-height: 0;
   opacity: var(--ezp-upload-header-opacity, 1);
   text-align: center;
   transition: filter var(--ezp-duration-3) var(--ezp-easing-out-quart),
     opacity var(--ezp-duration-3) var(--ezp-easing-out-quart);
+
+  /* When files are selected, collapse the drop-zone icon and primary description
+     so the file list has more breathing room (especially inside small modals).
+     The "select files" link stays so users can still add more files. */
+  &:has(#file-list) {
+    gap: var(--ezp-spacing-3);
+
+    > ezp-icon {
+      display: none;
+    }
+
+    > ezp-label:first-of-type {
+      display: none;
+    }
+  }
 }
 
 #meta {
@@ -78,9 +111,31 @@
 #file-list {
   display: flex;
   flex-direction: column;
+  gap: var(--ezp-spacing-3);
   width: 100%;
-  height: 35vh;
+  flex: 0 1 auto;       /* can shrink when #header runs out of vertical space */
+  max-height: 240px;
+  min-height: 0;
   overflow-y: auto;
+
+  /* Cross-platform thin scrollbar — Windows default is too chunky for this size. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--ezp-core-foreground-tertiary) transparent;
+
+  /* WebKit fallback for older Safari / Chrome that don't honor scrollbar-width. */
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--ezp-core-foreground-tertiary);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
 }
 
 .file-item {

--- a/src/components/ezp-upload/ezp-upload.scss
+++ b/src/components/ezp-upload/ezp-upload.scss
@@ -12,7 +12,7 @@
   box-sizing: border-box;
   color: var(--ezp-core-foreground-primary);
   display: grid;
-  grid-template-columns: minmax(auto, 480px);
+  grid-template-columns: minmax(auto, 280px);
   grid-template-rows: minmax(0, 1fr);
   height: var(--ezp-upload-height, auto);
   /* Allow shrinking when constrained by a flex parent (e.g. inside ezp-printing in a small modal). */
@@ -114,7 +114,7 @@
   gap: var(--ezp-spacing-3);
   width: 100%;
   flex: 0 1 auto;       /* can shrink when #header runs out of vertical space */
-  max-height: 240px;
+  max-height: var(--ezp-upload-fileList-maxHeight, 240px);
   min-height: 0;
   overflow-y: auto;
 


### PR DESCRIPTION
…ents

  Closes #472

  In the Print Now upload flow, ezp-upload (drop zone + file list) and
  ezp-auth (Cancel + Select Printer buttons) were rendered as plain block
  siblings inside ezp-printing with no layout coordination. When the
  parent (e.g. a Print Now modal in ezd-frontend) constrained the
  component's height, ezp-upload's natural height pushed ezp-auth past
  the visible area and the action buttons disappeared.

  Lay out ezp-printing's :host as a flex column with max-height: 100%
  and min-height: 0 so it respects parent constraints. Make ezp-upload
  flex: 1 1 auto (takes available space, can shrink) and ezp-auth
  flex-shrink: 0 (always visible at the bottom).