### PR TITLE
fix: apply patch-package on prepare instead of postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "stylelint": "stylelint \"**/*.scss\" --fix",
     "prettier": "prettier \"**/*.{json,ts,tsx,md,html}\" --write",
     "format": "npm run stylelint && npm run prettier",
-    "postinstall": "patch-package"
+    "prepare": "patch-package"
   },
   "dependencies": {
     "@azure/storage-blob": "^12.8.0",

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,6 +1,8 @@
 # Patches
 
-Patches in this directory are applied via [`patch-package`](https://github.com/ds300/patch-package) on `postinstall` (see `package.json` → `scripts.postinstall`).
+Patches in this directory are applied via [`patch-package`](https://github.com/ds300/patch-package) on `prepare` (see `package.json` → `scripts.prepare`).
+
+`prepare` runs after `npm install`/`npm ci` in this repo and before `npm pack`/`npm publish`, so the patch is applied for local development and at publish time. It deliberately does **not** run when `@ezeep/ezeep-js` is installed as a dependency by a downstream consumer (npm runs `prepare` only for the package's own install and for git installs, not for registry/tarball deps). That matters because `patch-package` is a `devDependency`, so a `postinstall` here would fail every consumer install with `patch-package: not found` (exit 127). The patch only touches build-time SCSS and never ships in `dist/`, so consumers never need it.
 
 ## Version coupling — read before bumping a patched dependency
 


### PR DESCRIPTION
The build-ng job has been failing on every push to main since the Stencil 4 upgrade (#95 on May 12), and it failed again on #96. The error is always the same:

```
npm error command sh -c patch-package
npm error sh: 1: patch-package: not found
npm error code 127
```

This isn't caused by the print-orientation work, that branch just inherited it.

## What's going on

#95 added a `postinstall` script that runs `patch-package`, but `patch-package` is only a devDependency. The postinstall ships in the published package and runs on every install, including when `@ezeep/ezeep-js` gets installed as a dependency by the build-ng job (into the ngx-ezeep-js Angular project). A dependency's devDependencies don't get installed, so the `patch-package` binary isn't there and the script exits 127. The same thing breaks any external consumer running `npm install @ezeep/ezeep-js`.

build-npm passes because it installs this repo's own devDependencies, so `patch-package` is present there. The break only shows up where the package is consumed as a dependency.

## The fix

Move the hook from `postinstall` to `prepare`. `prepare` still runs on local `npm install` and `npm ci`, and before `npm pack` and `npm publish`, so the patch keeps getting applied for local development and at publish time. npm does not run `prepare` for registry or tarball dependency installs, so consumers never trigger it. The patch only edits build-time SCSS in `@cortado-holding/colors` that never ships in `dist/`, so consumers don't need it anyway.

## Verifying it

I reproduced the failure locally before changing anything by packing the package and installing the tarball as a dependency in a clean directory. It failed with exit 127, same as CI. After moving the hook to `prepare` the same install succeeds (added 48 packages, no errors), and `npm pack` still runs `patch-package` and applies the patch, so local dev and publishing are unaffected.

One thing worth flagging. The versions already published to npm between May 12 and now still carry the broken postinstall, so anyone pinned to one of those still hits it. Those can be deprecated separately if you want, but it's not needed to get the pipeline green.