### PR TITLE
fix: point package types and module at the loader output

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "url": "git+https://github.com/ezeep/ezeep-js.git"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/custom-elements/index.js",
+  "module": "loader/index.js",
   "es2015": "dist/esm/index.mjs",
   "es2017": "dist/esm/index.mjs",
-  "types": "dist/custom-elements/index.d.ts",
+  "types": "loader/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/ezeep-js/ezeep-js.esm.js",


### PR DESCRIPTION
The build-ng job still fails after #97, but for a different reason now. The patch-package fix got the install working, so the build now reaches the Angular compile, which dies with a missing type declaration for `@ezeep/ezeep-js`:

```
error TS7016: Could not find a declaration file for module '@ezeep/ezeep-js'.
'.../node_modules/@ezeep/ezeep-js/dist/index.cjs.js' implicitly has an 'any' type.
```

This is a second thing the Stencil 4 upgrade (#95) broke, it was just hidden behind the install failure until now.

## What's going on

#95 switched the custom-elements output target from `dist-custom-elements-bundle` to `dist-custom-elements`. The old target wrote to `dist/custom-elements/`, the new one writes to `dist/components/`. package.json was never updated and still pointed `module` and `types` at the old path:

```json
"module": "dist/custom-elements/index.js",
"types":  "dist/custom-elements/index.d.ts",
```

I checked the published 1.0.270 tarball. It ships `dist/components/`, `dist/types/` and `loader/`, with no `dist/custom-elements/` anywhere. So the package has no resolvable types, TypeScript falls back to `main` (`dist/index.cjs.js`), and `noImplicitAny` turns that into the TS7016 above.

The wrapper imports both `Components` and `defineCustomElements` from the package root. Reading the published `.d.ts` files, `loader/index.d.ts` is the only entry that still exports both. `dist/components` only exports `Components`, not `defineCustomElements`. The old bundle exported both from the root, which is why this compiled fine at #93.

## The fix

Point `types` and `module` at the loader output.

```diff
-  "module": "dist/custom-elements/index.js",
-  "types": "dist/custom-elements/index.d.ts",
+  "module": "loader/index.js",
+  "types": "loader/index.d.ts",
```

## Verifying it

I reproduced it against the actual published 1.0.270 package with tsc 5.9.3. Before the change, importing `Components` and `defineCustomElements` both throw TS7016, the same as CI. After repointing `types` and `module` to the loader, it compiles clean and both resolve from the root.

This is a package.json-only change, nothing needs to change on the ngx-ezeep-js branch. A more modern alternative would be to regenerate the Angular wrapper so it imports `defineCustomElements` from `@ezeep/ezeep-js/loader`, but that touches the angular branch and isn't needed to get green.