### PR TITLE
fix: support the Angular 20 ngx-ezeep-js wrapper in the build-ng job

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -121,7 +121,7 @@ jobs:
         cd projects/ngx-ezeep-js
         npm install
         cd ../..
-        ng build ngx-ezeep-js --prod
+        ng build ngx-ezeep-js
         cd dist/ngx-ezeep-js
         # Hier ebenfalls npx nutzen, um die OIDC-kompatible npm Version zu erzwingen
         npx -p npm@latest npm publish --access public --provenance

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -18,6 +18,14 @@ export const config: Config = {
     angularOutputTarget({
       componentCorePackage: '@ezeep/ezeep-js',
       directivesProxyFile: 'dist/directives/proxies.ts',
+      // Generate proxies that import each component from the custom-elements
+      // build and self-define it, instead of the lazy `defineCustomElements`
+      // loader. The lazy loader fetches per-component chunks at runtime, which
+      // does not resolve inside a bundler (Angular/esbuild), so the components
+      // never render in a consumer app. Importing from dist/components lets the
+      // consumer's bundler include the component code statically.
+      includeImportCustomElements: true,
+      customElementsDir: 'dist/components',
     }),
     {
       type: 'dist',


### PR DESCRIPTION
The main-side half of restoring the build-ng job. It pairs with the Angular 20 wrapper upgrade in ezeep/ezeep-js#99 (on the ngx-ezeep-js branch).

## What

- `stencil.config.ts`: set `includeImportCustomElements` and `customElementsDir` on the `angularOutputTarget`. The generated proxies now import and define each component from `@ezeep/ezeep-js/dist/components` instead of relying on the lazy `defineCustomElements` loader. The lazy loader fetches per-component chunks at runtime, which does not resolve inside a modern bundler (esbuild/Vite), so the components never define in a consumer app. This only changes the generated Angular proxies, not the core's runtime output.
- `.github/workflows/node.js.yml`: drop the `--prod` flag from the build-ng step. It was removed in Angular 13 and errors on Angular 20 with `Unknown argument: prod`. Production is already the default configuration.

## Why

After the Stencil 4 upgrade, build-ng failed in three layers: patch-package on install (#97), the package types path (#98), and finally the wrapper toolchain being too old to parse Stencil 4's TypeScript 5 type output. The wrapper move to Angular 20 fixes the last one, and these two changes are what the regenerated, modern-bundler-friendly proxies and the new CLI need on the main side.

## Coordination

Merge ezeep/ezeep-js#99 into `ngx-ezeep-js` first, then this PR into `main`. The next push to main then runs build-ng with both halves in place: build-npm regenerates the proxies in the new style, and the build-ng job checks out the upgraded Angular 20 wrapper and compiles against them.

A control test (the published 1.0.267 and the ~7-month-old 1.0.257 wrappers) showed `ezp-printing` does not visibly render in a bare consumer app on any version, because it gates its UI on a backend call. That is pre-existing and unrelated to this change. These PRs restore the build and publish, and make the wrapper load cleanly in modern bundlers.