### PR TITLE
Redesign print flow: Print Now upload, print options, and cancel behavior

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -576,6 +576,7 @@ declare global {
     interface HTMLEzpUploadElementEventMap {
         "uploadFile": File[];
         "uploadContinue": File[];
+        "printCancel": MouseEvent;
     }
     interface HTMLEzpUploadElement extends Components.EzpUpload, HTMLStencilElement {
         addEventListener<K extends keyof HTMLEzpUploadElementEventMap>(type: K, listener: (this: HTMLEzpUploadElement, ev: EzpUploadCustomEvent<HTMLEzpUploadElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -985,6 +986,10 @@ declare namespace LocalJSX {
         "type"?: TextButtonTypeTypes;
     }
     interface EzpUpload {
+        /**
+          * Fired when the user cancels, closing the print flow in the host app.
+         */
+        "onPrintCancel"?: (event: EzpUploadCustomEvent<MouseEvent>) => void;
         /**
           * Fired when the user confirms the selection and wants to move on to print options.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -846,7 +846,7 @@ declare namespace LocalJSX {
          */
         "language"?: string;
         /**
-          * Events
+          * Fired when the print flow reaches an end state and the host may dismiss the component: a print job was submitted, or the user cancelled on the upload card, the sign-in dialog (with files pending) or the print options card. It does not mean a job was printed — check for that on the print API side.
          */
         "onPrintFinished"?: (event: EzpPrintingCustomEvent<void>) => void;
         "printapihosturl"?: string;

--- a/src/components/ezp-icon-button/readme.md
+++ b/src/components/ezp-icon-button/readme.md
@@ -22,7 +22,6 @@
  - [ezp-dialog](../ezp-dialog)
  - [ezp-printer-selection](../ezp-printer-selection)
  - [ezp-printing](../ezp-printing)
- - [ezp-upload](../ezp-upload)
  - [ezp-user-menu](../ezp-user-menu)
 
 ### Depends on
@@ -36,7 +35,6 @@ graph TD;
   ezp-dialog --> ezp-icon-button
   ezp-printer-selection --> ezp-icon-button
   ezp-printing --> ezp-icon-button
-  ezp-upload --> ezp-icon-button
   ezp-user-menu --> ezp-icon-button
   style ezp-icon-button fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/ezp-printing/ezp-printing.spec.tsx
+++ b/src/components/ezp-printing/ezp-printing.spec.tsx
@@ -117,6 +117,23 @@ describe('ezp-printing journey', () => {
     expect(finished).toBe(true)
   })
 
+  it('userCancel discards the pending files and ends the flow for the host', async () => {
+    const { page, el } = await setup('trigger="file"')
+    el.listenUploadContinue({ detail: [new File(['x'], 'report.pdf')] })
+    await page.waitForChanges()
+    expect(el.authOpen).toBe(true)
+
+    let finished = false
+    page.root!.addEventListener('printFinished', (() => (finished = true)) as EventListener)
+
+    el.listenUserCancel()
+    await page.waitForChanges()
+    expect(el.authOpen).toBe(false)
+    expect(el.files).toEqual([])
+    expect(el.filename).toBe('')
+    expect(finished).toBe(true)
+  })
+
   it('authCancel closes the auth dialog', async () => {
     const { page, el } = await setup('trigger="file"')
     el.listenUploadContinue({ detail: [new File(['x'], 'report.pdf')] })

--- a/src/components/ezp-printing/ezp-printing.tsx
+++ b/src/components/ezp-printing/ezp-printing.tsx
@@ -160,6 +160,9 @@ export class EzpPrinting {
       detail: {},
     })
     document.dispatchEvent(printCancelEvent)
+    // Cancelling sign-in with files pending discards them, so the flow is over
+    // for the host — same signal as cancelling on the upload or print step.
+    this.printFinished.emit()
     this.checkAuth()
   }
 
@@ -216,6 +219,12 @@ export class EzpPrinting {
    * Events
    */
 
+  /**
+   * Fired when the print flow reaches an end state and the host may dismiss the
+   * component: a print job was submitted, or the user cancelled on the upload
+   * card, the sign-in dialog (with files pending) or the print options card. It
+   * does not mean a job was printed — check for that on the print API side.
+   */
   @Event({
     eventName: 'printFinished',
     composed: true,

--- a/src/components/ezp-printing/readme.md
+++ b/src/components/ezp-printing/readme.md
@@ -30,9 +30,9 @@
 
 ## Events
 
-| Event           | Description | Type                |
-| --------------- | ----------- | ------------------- |
-| `printFinished` | Events      | `CustomEvent<void>` |
+| Event           | Description                                                                                                                                                                                                                                                                                               | Type                |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `printFinished` | Fired when the print flow reaches an end state and the host may dismiss the component: a print job was submitted, or the user cancelled on the upload card, the sign-in dialog (with files pending) or the print options card. It does not mean a job was printed — check for that on the print API side. | `CustomEvent<void>` |
 
 
 ## Methods

--- a/src/components/ezp-printing/readme.md
+++ b/src/components/ezp-printing/readme.md
@@ -123,12 +123,11 @@ graph TD;
   ezp-printing --> ezp-auth
   ezp-printing --> ezp-printer-selection
   ezp-printing --> ezp-dialog
-  ezp-upload --> ezp-label
-  ezp-upload --> ezp-icon-button
   ezp-upload --> ezp-icon
+  ezp-upload --> ezp-label
   ezp-upload --> ezp-text-button
-  ezp-icon-button --> ezp-icon
   ezp-text-button --> ezp-label
+  ezp-icon-button --> ezp-icon
   ezp-auth --> ezp-status
   ezp-auth --> ezp-dialog
   ezp-status --> ezp-icon

--- a/src/components/ezp-upload/ezp-upload.scss
+++ b/src/components/ezp-upload/ezp-upload.scss
@@ -53,25 +53,6 @@
 
 /**
  *
- * Header
- *
- */
-
-#header {
-  align-items: center;
-  border-bottom: 1px solid var(--ezp-core-outline);
-  display: flex;
-  justify-content: space-between;
-  padding-bottom: var(--ezp-spacing-4);
-}
-
-#heading {
-  --ezp-label-fontSize: 22px;
-  --ezp-label-lineHeight: 28px;
-}
-
-/**
- *
  * Dropzone
  *
  */

--- a/src/components/ezp-upload/ezp-upload.spec.tsx
+++ b/src/components/ezp-upload/ezp-upload.spec.tsx
@@ -77,17 +77,15 @@ describe('ezp-upload', () => {
     expect(advanced[0].map((f: File) => f.name)).toEqual(['a.pdf'])
   })
 
-  it('clearSelection empties the selection and re-emits an empty uploadFile', async () => {
+  it('handleCancel emits printCancel so the host closes the flow', async () => {
     const { page, up } = await setup()
-    up.form = { reset: () => undefined }
-    const emitted: File[][] = []
-    page.root!.addEventListener('uploadFile', ((e: CustomEvent<File[]>) => {
-      emitted.push(e.detail)
-    }) as EventListener)
+    let cancels = 0
+    page.root!.addEventListener('printCancel', () => {
+      cancels++
+    })
 
     up.handleDrop(dropEvent([new File(['1'], 'a.pdf')]))
-    up.clearSelection()
-    expect(up.selectedFiles).toEqual([])
-    expect(emitted[emitted.length - 1]).toEqual([])
+    up.handleCancel()
+    expect(cancels).toBe(1)
   })
 })

--- a/src/components/ezp-upload/ezp-upload.tsx
+++ b/src/components/ezp-upload/ezp-upload.tsx
@@ -44,6 +44,9 @@ export class EzpUpload {
   /** Fired when the user confirms the selection and wants to move on to print options. */
   @Event() uploadContinue: EventEmitter<File[]>
 
+  /** Fired when the user cancels, closing the print flow in the host app. */
+  @Event() printCancel: EventEmitter<MouseEvent>
+
   /**
    *
    * Listeners
@@ -115,10 +118,11 @@ export class EzpUpload {
     }
   }
 
-  private clearSelection = () => {
-    this.form?.reset()
-    this.selectedFiles = []
-    this.uploadFile.emit(this.selectedFiles)
+  private handleCancel = () => {
+    // Closing is the host's call: the event bubbles to `ezp-printing`, which
+    // ends the print flow. It also reaches the document, where our own
+    // `printCancel` listener resets the form and the selection.
+    this.printCancel.emit()
   }
 
   private handleContinue = () => {
@@ -168,16 +172,6 @@ export class EzpUpload {
           />
 
           <div id="modal">
-            <div id="header">
-              <ezp-label id="heading" weight="heavy" text={i18next.t('upload.heading')} />
-              <ezp-icon-button
-                icon="close"
-                type="button"
-                level="tertiary"
-                onClick={this.clearSelection}
-              />
-            </div>
-
             <div id="dropzone">
               {hasFiles && (
                 <div id="thumbs">
@@ -250,7 +244,7 @@ export class EzpUpload {
               <ezp-text-button
                 type="button"
                 level="secondary"
-                onClick={this.clearSelection}
+                onClick={this.handleCancel}
                 label={i18next.t('button_actions.cancel')}
                 class="action"
               />

--- a/src/components/ezp-upload/readme.md
+++ b/src/components/ezp-upload/readme.md
@@ -5,10 +5,11 @@
 
 ## Events
 
-| Event            | Description                                                                       | Type                  |
-| ---------------- | --------------------------------------------------------------------------------- | --------------------- |
-| `uploadContinue` | Fired when the user confirms the selection and wants to move on to print options. | `CustomEvent<File[]>` |
-| `uploadFile`     | Keeps the parent's file state in sync as the selection changes.                   | `CustomEvent<File[]>` |
+| Event            | Description                                                                       | Type                      |
+| ---------------- | --------------------------------------------------------------------------------- | ------------------------- |
+| `printCancel`    | Fired when the user cancels, closing the print flow in the host app.              | `CustomEvent<MouseEvent>` |
+| `uploadContinue` | Fired when the user confirms the selection and wants to move on to print options. | `CustomEvent<File[]>`     |
+| `uploadFile`     | Keeps the parent's file state in sync as the selection changes.                   | `CustomEvent<File[]>`     |
 
 
 ## Dependencies
@@ -19,19 +20,16 @@
 
 ### Depends on
 
-- [ezp-label](../ezp-label)
-- [ezp-icon-button](../ezp-icon-button)
 - [ezp-icon](../ezp-icon)
+- [ezp-label](../ezp-label)
 - [ezp-text-button](../ezp-text-button)
 
 ### Graph
 ```mermaid
 graph TD;
-  ezp-upload --> ezp-label
-  ezp-upload --> ezp-icon-button
   ezp-upload --> ezp-icon
+  ezp-upload --> ezp-label
   ezp-upload --> ezp-text-button
-  ezp-icon-button --> ezp-icon
   ezp-text-button --> ezp-label
   ezp-printing --> ezp-upload
   style ezp-upload fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/data/locales/de.json
+++ b/src/data/locales/de.json
@@ -64,7 +64,6 @@
     "upload": {
         "description": "Ziehe Dateien hier in den Browser ",
         "meta_leading": "oder",
-        "heading": "Jetzt drucken",
         "dropzone_title": "Dateien hier ablegen",
         "browse": "vom Gerät auswählen",
         "file_type_fallback": "DATEI",

--- a/src/data/locales/en.json
+++ b/src/data/locales/en.json
@@ -64,7 +64,6 @@
     "upload": {
         "description": "Drop files here into the browser ",
         "meta_leading": "or",
-        "heading": "Print Now",
         "dropzone_title": "Drop files here",
         "browse": "select from device",
         "file_type_fallback": "FILE",


### PR DESCRIPTION
Redesign of the print flow in the ezeep-js web components, plus the follow-up fixes made on top of it.

## What changed

- **Print Now upload step.** New `ezp-upload` layout: a full-height dashed dropzone, cloud-upload icon, supported-format chips, multi-file selection with thumbnails, per-file remove, an "Add" tile, and a files-ready counter. Files accumulate across drops and picks instead of replacing the previous selection.
- **Print options step.** `ezp-printer-selection` was restyled to match: reworked header, file list with a count badge, and a new action bar. The print button is now a native `<button>` styled in place.
- **Status feedback.** `ezp-status` gained a `subtext` property and updated styling so success and error states read more clearly.
- **Auth step.** The intermediate confirm screen in `ezp-auth` was removed; the sign-in window opens directly and the component shows a processing state.
- **Colors.** Cyan brand values were corrected via a patch to `@cortado-holding/colors` (`patches/@cortado-holding+colors+2.0.5.patch`), with the override documented in `patches/README.md`.
- **Modal header removed.** The Print Now card no longer renders a heading row or a close icon, so the dropzone is the top element.
- **Cancel closes the flow.** The footer Cancel button used to only empty the file selection. It now emits `printCancel`, the same event `ezp-printer-selection` already used, so `ezp-printing` ends the flow, clears the files and emits `printFinished` to the host application.

## How it was implemented

The upload component keeps its own `selectedFiles` state and emits `uploadFile` on every change so `ezp-printing` stays in sync, and `uploadContinue` when the user advances. Cancelling is delegated upward rather than handled locally: the emitted `printCancel` bubbles to `ezp-printing`, which closes the flow and re-dispatches the event on `document`, where the upload component's own listener resets the form. Per-file removal stays local.

Earlier review findings were folded in along the way: i18next plural keys for the file counters, the dead `userCancel` path, and a dedicated `FILE` label for extensionless files.

## Dependencies

No new dependencies. `package.json` and `package-lock.json` are unchanged relative to `main`. The only third-party adjustment is the existing patch-package override of `@cortado-holding/colors@2.0.5`.

## Verification

Lint clean (0 errors), 146 spec tests and 3 e2e tests pass, `stencil build --docs` succeeds. Generated typings and readme docs are regenerated and committed. An AI review following the team's code review template is posted as the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
